### PR TITLE
Fix: Next.js vulnerability workaround

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -57,4 +57,8 @@ module.exports = {
     hardCapLimit,
     ethplorerMainnetUrl,
   },
+  // WARNING: Vulnerability fix, don't remove until default Next.js image loader is patched
+  images: {
+    loader: 'custom',
+  },
 };


### PR DESCRIPTION
I quickly checked myself, but please double-check `next/image` is not used in this repo before merging.