### PR TITLE
Fix: MATIC equiv value on first load issue

### DIFF
--- a/components/wallet/wallet.tsx
+++ b/components/wallet/wallet.tsx
@@ -33,6 +33,12 @@ const Wallet: WalletComponent = (props) => {
     params: [account],
   });
 
+  const stMaticBalance = useContractSWR({
+    contract: stMaticTokenRPC,
+    method: 'balanceOf',
+    params: [account],
+  });
+
   const [maticEquiv, setMaticEquiv] = useState<BigNumber>();
   const [maticSymbol, setMaticSymbol] = useState('MATIC');
   const [stMaticSymbol, setStMaticSymbol] = useState('stMATIC');
@@ -58,19 +64,15 @@ const Wallet: WalletComponent = (props) => {
       });
 
       const amount = utils.parseUnits(
-        formatBalance(maticBalance.data),
+        formatBalance(stMaticBalance.data),
         'ether',
       );
       stMaticTokenWeb3.convertStMaticToMatic(amount).then(([res]) => {
         setMaticEquiv(res);
       });
     }
-  }, [maticTokenWeb3, stMaticTokenWeb3]);
-  const stMaticBalance = useContractSWR({
-    contract: stMaticTokenRPC,
-    method: 'balanceOf',
-    params: [account],
-  });
+  }, [maticTokenWeb3, stMaticTokenWeb3, stMaticBalance.data]);
+
   return (
     <WalletCard {...props}>
       <WalletCardRow>


### PR DESCRIPTION
## Description
This PR should fix the absence of MATIC equivalent of the stMATIC on the wallet component on the first load

## Extra (important!)
- corrected input of the convert function (take staked matic value instead of owned amount of MATIC)