### PR TITLE
Fix: Absence of values at load time

### DIFF
--- a/components/inputRightDecorator/InputRightDecorator.tsx
+++ b/components/inputRightDecorator/InputRightDecorator.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import styled from 'styled-components';
 
-import { FC, useRef, useState } from 'react';
+import { FC, useRef, useState, useEffect } from 'react';
 import { Button, Popover } from '@lidofinance/lido-ui';
 
 import batteryLow from 'public/icons/low-battery.svg';
@@ -60,16 +60,24 @@ const InputRightDecorator: FC<InputRightDecoratorProps> = ({
   const handleToggle = () => {
     setIsPopoverOpen((state) => !state);
   };
+  const [price, setPrice] = useState(1.6);
+
+  useEffect(() => {
+    fetch('api/stats').then((res) =>
+      res.json().then((res) => setPrice(res.price)),
+    );
+  }, []);
+
   return (
     <Wrapper>
       {hardCapLimit ? (
         <>
           <img
             src={
-              currentStakeCapacityPercentage >= 100
+              currentStakeCapacityPercentage * price >= 100
                 ? batteryFull
-                : currentStakeCapacityPercentage < 100 &&
-                  currentStakeCapacityPercentage >= 50
+                : currentStakeCapacityPercentage * price < 100 &&
+                  currentStakeCapacityPercentage * price >= 50
                 ? batteryHalf
                 : batteryLow
             }
@@ -114,12 +122,12 @@ const InputRightDecorator: FC<InputRightDecoratorProps> = ({
               <TotalStake>
                 <span>Total stake capacity: </span>
                 <span>{`$${formatCash(
-                  +currentlyStakedAmount * 1.6,
-                )} / $${formatCash(
-                  10000000,
-                )} (${currentStakeCapacityPercentage.toFixed(2)}%)`}</span>
+                  +currentlyStakedAmount * price,
+                )} / $${formatCash(hardCapLimit)} (${(
+                  currentStakeCapacityPercentage * price
+                ).toFixed(2)}%)`}</span>
               </TotalStake>
-              <ProgressBar completed={currentStakeCapacityPercentage} />
+              <ProgressBar completed={currentStakeCapacityPercentage * price} />
             </PopoverContent>
           </Popover>
         </>

--- a/components/stake/stake.tsx
+++ b/components/stake/stake.tsx
@@ -328,14 +328,14 @@ const Stake: FC = () => {
   };
 
   useEffect(() => {
-    if (lidoMaticWeb3) {
+    if (lidoMaticRpc) {
       const amount = utils.parseUnits('1', 'ether');
-      lidoMaticWeb3.convertMaticToStMatic(amount).then(([res]) => {
+      lidoMaticRpc.convertMaticToStMatic(amount).then(([res]) => {
         setRate(formatBalance(res));
       });
 
       if (hardCapLimit.current) {
-        lidoMaticWeb3.getTotalPooledMatic().then((res) => {
+        lidoMaticRpc.getTotalPooledMatic().then((res) => {
           if (+hardCapLimit.current <= Number(utils.formatEther(res))) {
             setCanUnlock(false);
             setCanStake(false);
@@ -347,7 +347,7 @@ const Stake: FC = () => {
         });
       }
     }
-  }, [enteredAmount, lidoMaticWeb3, totalPooledMatic]);
+  }, [enteredAmount, lidoMaticRpc, totalPooledMatic]);
 
   useEffect(() => {
     if (lidoMaticWeb3) {
@@ -399,7 +399,7 @@ const Stake: FC = () => {
         />
       </form>
       <DataTable>
-        <DataTableRow title="You will recieve">
+        <DataTableRow title="You will receive">
           {reward} {stSymbol}
         </DataTableRow>
         <DataTableRow title="Exchange rate">

--- a/components/unstake/unstake.tsx
+++ b/components/unstake/unstake.tsx
@@ -204,13 +204,13 @@ const Unstake: FC<{ changeTab: (tab: string) => void }> = ({ changeTab }) => {
   };
 
   useEffect(() => {
-    if (lidoMaticWeb3) {
+    if (stMaticTokenRPC) {
       const amount = utils.parseUnits('1', 'ether');
-      lidoMaticWeb3.convertMaticToStMatic(amount).then(([res]) => {
+      stMaticTokenRPC.convertStMaticToMatic(amount).then(([res]) => {
         setRate(formatBalance(res));
       });
     }
-  }, [lidoMaticWeb3]);
+  }, [stMaticTokenRPC]);
   useEffect(() => {
     if (lidoMaticWeb3) {
       lidoMaticWeb3?.symbol().then((res) => {
@@ -338,8 +338,8 @@ const Unstake: FC<{ changeTab: (tab: string) => void }> = ({ changeTab }) => {
       setReward('0');
       setCanApprove(false);
       setCanUnstake(false);
-    } else if (lidoMaticWeb3 && +amount > 0) {
-      lidoMaticWeb3
+    } else if (stMaticTokenRPC && +amount > 0) {
+      stMaticTokenRPC
         .convertStMaticToMatic(utils.parseUnits(amount, 'ether'))
         .then(([res]) => {
           setReward(formatBalance(res));
@@ -410,7 +410,7 @@ const Unstake: FC<{ changeTab: (tab: string) => void }> = ({ changeTab }) => {
         />
       </form>
       <DataTable>
-        <DataTableRow title="You will recieve">
+        <DataTableRow title="You will receive">
           {reward} {symbol}
         </DataTableRow>
         <DataTableRow title="Exchange rate">

--- a/components/unstake/unstake.tsx
+++ b/components/unstake/unstake.tsx
@@ -414,7 +414,7 @@ const Unstake: FC<{ changeTab: (tab: string) => void }> = ({ changeTab }) => {
           {reward} {symbol}
         </DataTableRow>
         <DataTableRow title="Exchange rate">
-          1 {symbol} = {rate} {stSymbol}
+          1 {stSymbol} = {rate} {symbol}
         </DataTableRow>
       </DataTable>
       <StatusModal


### PR DESCRIPTION
### this branch is rebased to lido's **develop**

## Description
This PR should fix the problem of the absence/inaccuracy of indicative values on the first load (when the wallet is not connected), values:
- Total staked amount
- Exchange rate

## Important notes
- The max stake amount of $10M is now gotten from the env variable **HARD_CAP_LIMIT** instead of being hardcoded into the code *(only on the popup, other places already use it)* . SO the prod env file must have the correct value
- The price used to convert MATIC to Dollars is gotten from **api/stats** instead of being hardcoded as (1,6). WHICH will result in slight difference of the result compared to the version already on prod

## Extra
- Fixed a typo on both stake and unstake tabs (recieve -> receive)
- Included switch of MATIC x stMATIC symbols on unstake tab